### PR TITLE
Fetch Artist Albums Information via Spotify API

### DIFF
--- a/tunalyze/pyproject.toml
+++ b/tunalyze/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "tunalyze"
-version = "0.1.14"
+version = "0.1.15"
 description = "About An innovative music analysis tool leveraging Spotify API to provide in-depth insights into track attributes for genre trends, era evolution, and mood-based music exploration. Ideal for music enthusiasts, producers, and marketers seeking data-driven inspiration and strategic decision-making."
 authors = [{ name = "hid3xxx", email = "" }]
 dependencies = ["python-dotenv>=1.0.0", "spotipy>=2.23.0"]

--- a/tunalyze/src/spotify/artist_albums.py
+++ b/tunalyze/src/spotify/artist_albums.py
@@ -1,0 +1,242 @@
+"""This module provides classes to interact with the Spotify API for retrieving albums of specific artists.
+
+It includes the SpotifyArtistAlbums class for making API requests to Spotify and a factory class
+SpotifyArtistAlbumsFactory for creating instances of SpotifyArtistAlbums with different configurations.
+"""
+
+import re
+from typing import Any
+
+from spotipy.exceptions import SpotifyException
+from spotipy.oauth2 import SpotifyOauthError
+
+from src.spotify.api_base import SpotifyAPIBase
+from src.spotify.error_handler import SpotifyErrorHandler
+
+
+class SpotifyArtistAlbums(SpotifyAPIBase):
+    """This class is used to interact with the Spotify API to get albums of a specific artist.
+
+    Attributes:
+        artist_uri (str): The Spotify URI of the artist.
+        include_groups (str|None): A comma-separated list of album types to return.
+        limit (int): The number of items to return. Default is 10.
+        offset (int): The offset of the first item to return. Default is 0. Optional.
+    """
+
+    _MIN_LIMIT = 1
+    _MAX_LIMIT = 50
+    _LIMIT_ERROR_MESSAGE = (
+        f"Limit must be between {_MIN_LIMIT} and {_MAX_LIMIT}, inclusive."
+    )
+    _INVALID_URI_MESSAGE = (
+        "Invalid artist URI format. Expected format: 'spotify:artist:<Spotify ID>'."
+    )
+
+    def __init__(
+        self,
+        artist_uri: str,
+        include_groups: str | None = None,
+        limit: int = 10,
+        offset: int = 0,
+    ) -> None:
+        """Initializes the SpotifyArtistAlbums instance with the provided parameters.
+
+        Args:
+            artist_uri (str): The Spotify URI of the artist. Must be in the format 'spotify:artist:<Spotify ID>'.
+            include_groups (str|None): A comma-separated list of album types to return. Optional.
+            limit (int): The number of items to return. Default is 10. Optional.
+            offset (int): The offset of the first item to return. Default is 0. Optional.
+
+        Raises:
+            ValueError: If the artist URI format is invalid or the limit is outside the allowed range.
+        """
+        super().__init__()
+
+        # Validate artist URI
+        pattern = r"^spotify:artist:[0-9a-zA-Z]+$"
+        if not re.match(pattern, artist_uri):
+            raise ValueError(self._INVALID_URI_MESSAGE)
+        self.artist_uri = artist_uri.split(":")[-1]
+        self.include_groups = include_groups
+
+        # Validate limit
+        if not self._MIN_LIMIT <= limit <= self._MAX_LIMIT:
+            raise ValueError(self._LIMIT_ERROR_MESSAGE)
+        self.limit = limit
+        self.offset = offset
+
+    def __enter__(self) -> "SpotifyArtistAlbums":
+        """Reinitialize the client upon entering a context and return SpotifyArtistAlbums instance."""
+        super().__enter__()
+        return self
+
+    def get_albums(self) -> dict[str, Any]:
+        """Retrieves the albums of the specified artist from the Spotify API.
+
+        Returns:
+            dict[str, Any]: A dictionary containing information about the artist's albums.
+                            If an error occurs, it returns a dictionary with an error key.
+        """
+        try:
+            return self.client.sp.artist_albums(
+                artist_id=self.artist_uri,
+                album_type=self.include_groups,
+                limit=self.limit,
+                offset=self.offset,
+            )
+        except (SpotifyException, SpotifyOauthError) as e:
+            return SpotifyErrorHandler.handle_error(e)
+
+    def __str__(self) -> str:
+        """Return the string representation of the SpotifyArtistAlbums object.
+
+        Returns:
+            str: The string representation of the SpotifyArtistAlbums object.
+        """
+        return f"SpotifyArtistAlbums(artist_uri={self.artist_uri}, include_groups={self.include_groups}, limit={self.limit}, offset={self.offset})"
+
+
+class SpotifyArtistAlbumsFactory:
+    """Factory class to create SpotifyArtistAlbums objects for different album group types."""
+
+    @staticmethod
+    def artist_albums(
+        artist_uri: str, limit: int = 10, offset: int = 0
+    ) -> SpotifyArtistAlbums:
+        """Create a SpotifyArtistAlbums instance for retrieving all types of an artist's albums.
+
+        Args:
+            artist_uri (str): The Spotify URI of the artist.
+            limit (int): The number of albums to return. Default is 10.
+            offset (int): The offset of the first item to return. Default is 0.
+
+        Returns:
+            SpotifyArtistAlbums: An instance of SpotifyArtistAlbums.
+        """
+        return SpotifyArtistAlbums(artist_uri, None, limit, offset)
+
+    @staticmethod
+    def artist_albums_album(
+        artist_uri: str, limit: int = 10, offset: int = 0
+    ) -> SpotifyArtistAlbums:
+        """Create a SpotifyArtistAlbums instance for retrieving an artist's 'album' type albums.
+
+        Args:
+            artist_uri (str): The Spotify URI of the artist.
+            limit (int): The number of albums to return. Default is 10.
+            offset (int): The offset of the first item to return. Default is 0.
+
+        Returns:
+            SpotifyArtistAlbums: An instance of SpotifyArtistAlbums.
+        """
+        return SpotifyArtistAlbums(artist_uri, "album", limit, offset)
+
+    @staticmethod
+    def artist_albums_single(
+        artist_uri: str, limit: int = 10, offset: int = 0
+    ) -> SpotifyArtistAlbums:
+        """Create a SpotifyArtistAlbums instance for retrieving an artist's 'single' type albums.
+
+        Args:
+            artist_uri (str): The Spotify URI of the artist.
+            limit (int): The number of albums to return. Default is 10.
+            offset (int): The offset of the first item to return. Default is 0.
+
+        Returns:
+            SpotifyArtistAlbums: An instance of SpotifyArtistAlbums.
+        """
+        return SpotifyArtistAlbums(artist_uri, "single", limit, offset)
+
+    @staticmethod
+    def artist_albums_appears_on(
+        artist_uri: str, limit: int = 10, offset: int = 0
+    ) -> SpotifyArtistAlbums:
+        """Create a SpotifyArtistAlbums instance for retrieving an artist's 'appears_on' type albums.
+
+        Args:
+            artist_uri (str): The Spotify URI of the artist.
+            limit (int): The number of albums to return. Default is 10.
+            offset (int): The offset of the first item to return. Default is 0.
+
+        Returns:
+            SpotifyArtistAlbums: An instance of SpotifyArtistAlbums.
+        """
+        return SpotifyArtistAlbums(artist_uri, "appears_on", limit, offset)
+
+    @staticmethod
+    def artist_albums_compilation(
+        artist_uri: str, limit: int = 10, offset: int = 0
+    ) -> SpotifyArtistAlbums:
+        """Create a SpotifyArtistAlbums instance for retrieving an artist's 'compilation' type albums.
+
+        Args:
+            artist_uri (str): The Spotify URI of the artist.
+            limit (int): The number of albums to return. Default is 10.
+            offset (int): The offset of the first item to return. Default is 0.
+
+        Returns:
+            SpotifyArtistAlbums: An instance of SpotifyArtistAlbums.
+        """
+        return SpotifyArtistAlbums(artist_uri, "compilation", limit, offset)
+
+    @staticmethod
+    def artist_albums_album_single(
+        artist_uri: str, limit: int = 10, offset: int = 0
+    ) -> SpotifyArtistAlbums:
+        """Create a SpotifyArtistAlbums instance for retrieving an artist's 'album' and 'single' type albums.
+
+        Args:
+        artist_uri (str): The Spotify URI of the artist.
+        limit (int): The number of albums to return. Default is 10.
+        offset (int): The offset of the first item to return. Default is 0.
+
+        Returns:
+        SpotifyArtistAlbums: An instance of SpotifyArtistAlbums.
+        """
+        return SpotifyArtistAlbums(artist_uri, "album,single", limit, offset)
+
+    @staticmethod
+    def artist_albums_album_appears_on(
+        artist_uri: str, limit: int = 10, offset: int = 0
+    ) -> SpotifyArtistAlbums:
+        """Create a SpotifyArtistAlbums instance for retrieving an artist's 'album' and 'appears_on' type albums.
+
+        Args:
+        artist_uri (str): The Spotify URI of the artist.
+        limit (int): The number of albums to return. Default is 10.
+        offset (int): The offset of the first item to return. Default is 0.
+
+        Returns:
+        SpotifyArtistAlbums: An instance of SpotifyArtistAlbums.
+        """
+        return SpotifyArtistAlbums(artist_uri, "album,appears_on", limit, offset)
+
+    @staticmethod
+    def artist_albums_album_compilation(
+        artist_uri: str, limit: int = 10, offset: int = 0
+    ) -> SpotifyArtistAlbums:
+        """Create a SpotifyArtistAlbums instance for retrieving an artist's 'album' and 'compilation' type albums.
+
+        Args:
+        artist_uri (str): The Spotify URI of the artist.
+        limit (int): The number of albums to return. Default is 10.
+        offset (int): The offset of the first item to return. Default is 0.
+
+        Returns:
+        SpotifyArtistAlbums: An instance of SpotifyArtistAlbums.
+        """
+        return SpotifyArtistAlbums(artist_uri, "album,compilation", limit, offset)
+
+
+# Example usage
+if __name__ == "__main__":
+    artist_uri = "spotify:artist:1vCWHaC5f2uS3yhpwWbIA6"
+    with SpotifyArtistAlbumsFactory.artist_albums_album_single(
+        artist_uri, limit=1
+    ) as artist_albums:
+        album_results = artist_albums.get_albums()
+        if "error" in album_results:
+            print(album_results["error"])  # noqa: T201
+        else:
+            print(album_results)  # noqa: T201

--- a/tunalyze/tests/spotify/test_artist_albums.py
+++ b/tunalyze/tests/spotify/test_artist_albums.py
@@ -1,0 +1,134 @@
+import pytest
+from spotipy.exceptions import SpotifyException
+from spotipy.oauth2 import SpotifyOauthError
+
+from src.spotify.artist_albums import SpotifyArtistAlbums, SpotifyArtistAlbumsFactory
+
+# Constants for testing
+VALID_ARTIST_URI = "spotify:artist:1vCWHaC5f2uS3yhpwWbIA6"
+INVALID_ARTIST_URI = "invalid_uri"
+VALID_INCLUDE_GROUPS = "album,single"
+VALID_LIMIT = 10
+VALID_OFFSET = 0
+
+
+@pytest.fixture()
+def mock_spotify_client(mocker):
+    """A pytest fixture that creates a mock SpotifyClient."""
+    mock = mocker.patch("src.spotify.client.SpotifyClient", autospec=True)
+    mock_instance = mock.return_value
+    mock_instance.sp.artist_albums.return_value = {"albums": "mock albums"}
+    mock_instance.sp.artist_albums.side_effect = [
+        SpotifyException("Error"),
+        SpotifyOauthError("Auth Error"),
+    ]
+    return mock_instance
+
+
+# URI validation tests
+def test_validate_artist_uri():
+    """Test the URI validation in SpotifyArtistAlbums initialization."""
+    # Valid URI
+    valid_artist_albums = SpotifyArtistAlbums(VALID_ARTIST_URI)
+    assert valid_artist_albums.artist_uri == VALID_ARTIST_URI.split(":")[-1]
+
+    # Invalid URI
+    with pytest.raises(ValueError, match=SpotifyArtistAlbums._INVALID_URI_MESSAGE):
+        SpotifyArtistAlbums(INVALID_ARTIST_URI)
+
+
+# Initialization tests
+def test_spotify_artist_albums_initialization():
+    """Test the initialization of SpotifyArtistAlbums with valid parameters."""
+    artist_albums = SpotifyArtistAlbums(
+        VALID_ARTIST_URI, VALID_INCLUDE_GROUPS, VALID_LIMIT, VALID_OFFSET
+    )
+    assert artist_albums.artist_uri == VALID_ARTIST_URI.split(":")[-1]
+    assert artist_albums.include_groups == VALID_INCLUDE_GROUPS
+    assert artist_albums.limit == VALID_LIMIT
+    assert artist_albums.offset == VALID_OFFSET
+
+
+# Context manager tests
+def test_spotify_artist_albums_context_manager(mock_spotify_client):
+    """Test the context manager functionality of SpotifyArtistAlbums."""
+    with SpotifyArtistAlbums(VALID_ARTIST_URI) as artist_albums:
+        assert artist_albums.client.sp is not None
+    with pytest.raises(AttributeError):
+        _ = artist_albums.client
+
+
+# Test the get_albums method
+def test_get_albums_method(mock_spotify_client):
+    """Test the get_albums method of SpotifyArtistAlbums."""
+    artist_albums = SpotifyArtistAlbums(
+        VALID_ARTIST_URI, VALID_INCLUDE_GROUPS, VALID_LIMIT, VALID_OFFSET
+    )
+    result = artist_albums.get_albums()
+    assert result == {"albums": "mock albums"}
+    mock_spotify_client.sp.artist_albums.assert_called_once_with(
+        artist_id=VALID_ARTIST_URI.split(":")[-1],
+        album_type=VALID_INCLUDE_GROUPS,
+        limit=VALID_LIMIT,
+        offset=VALID_OFFSET,
+    )
+
+
+def test_get_albums_method_handles_exceptions(mock_spotify_client):
+    """Test the exception handling in the get_albums method of SpotifyArtistAlbums."""
+    artist_albums = SpotifyArtistAlbums(
+        VALID_ARTIST_URI, VALID_INCLUDE_GROUPS, VALID_LIMIT, VALID_OFFSET
+    )
+
+    # Testing SpotifyException handling
+    result = artist_albums.get_albums()
+    assert "error" in result
+
+    # Reset mock to test SpotifyOAuthError
+    mock_spotify_client.sp.artist_albums.side_effect = SpotifyOauthError("Auth Error")
+
+    # Testing SpotifyOAuthError handling
+    result = artist_albums.get_albums()
+    assert "error" in result
+
+
+# Test the __str__ method
+def test_str_method():
+    """Test the string representation of SpotifyArtistAlbums."""
+    artist_albums = SpotifyArtistAlbums(
+        VALID_ARTIST_URI, VALID_INCLUDE_GROUPS, VALID_LIMIT, VALID_OFFSET
+    )
+    assert (
+        str(artist_albums)
+        == f"SpotifyArtistAlbums(artist_uri={VALID_ARTIST_URI.split(':')[-1]}, include_groups={VALID_INCLUDE_GROUPS}, limit={VALID_LIMIT}, offset={VALID_OFFSET})"
+    )
+
+
+# Test SpotifyArtistAlbumsFactory with different include_group
+@pytest.mark.parametrize(
+    ("factory_method", "include_groups"),
+    [
+        (SpotifyArtistAlbumsFactory.artist_albums, None),
+        (SpotifyArtistAlbumsFactory.artist_albums_album, "album"),
+        (SpotifyArtistAlbumsFactory.artist_albums_single, "single"),
+        (SpotifyArtistAlbumsFactory.artist_albums_appears_on, "appears_on"),
+        (SpotifyArtistAlbumsFactory.artist_albums_compilation, "compilation"),
+        (SpotifyArtistAlbumsFactory.artist_albums_album_single, "album,single"),
+        (SpotifyArtistAlbumsFactory.artist_albums_album_appears_on, "album,appears_on"),
+        (
+            SpotifyArtistAlbumsFactory.artist_albums_album_compilation,
+            "album,compilation",
+        ),
+        # Add more methods and corresponding search types here
+    ],
+)
+
+# Test SpotifyArtistAlbumsFactory
+def test_spotify_artist_albums_factory(factory_method, include_groups):
+    """Test the factory methods of SpotifyArtistAlbumsFactory for creating artist albums instances."""
+    artist_albums = factory_method(VALID_ARTIST_URI, VALID_LIMIT, VALID_OFFSET)
+    assert isinstance(artist_albums, SpotifyArtistAlbums)
+    assert artist_albums.artist_uri == VALID_ARTIST_URI.split(":")[-1]
+    assert artist_albums.include_groups == include_groups
+    assert artist_albums.limit == VALID_LIMIT
+    assert artist_albums.offset == VALID_OFFSET


### PR DESCRIPTION
Implemented a new feature in the application that integrates with the Spotify API to fetch detailed album information for a specific artist. This enhancement allows users to input an artist's URI and retrieve all albums, including studio albums and EPs, released by that artist.
- Input handling for artist URIs using the Spotify API.
- Fetching of album data, including titles, release dates, cover arts, and track lists.
- Robust error handling for scenarios like invalid artist URIs or network issues.
- Additionally, developed comprehensive unit tests to validate the functionality, ensuring the correct handling of artist URIs, initialization of the SpotifyArtistAlbums class, context management, album retrieval process, and error scenarios.